### PR TITLE
fix: Modify config files for module alias

### DIFF
--- a/front-end/.babelrc
+++ b/front-end/.babelrc
@@ -8,9 +8,10 @@
       {
         "root": ["./"],
         "alias": {
-        "@src": "./src"
-      },
-      "extensions": [".js", ".jsx", ".tsx"]
+          "@components": "./components",
+          "@interfaces": "./interfaces"
+        },
+        "extensions": [".js", ".jsx", ".tsx"]
       }
     ]
   ]

--- a/front-end/next.config.js
+++ b/front-end/next.config.js
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
+const path = require('path');
 module.exports = {
   reactStrictMode: true,
+  webpack(config, options) {
+    config.resolve = {
+      alias: {
+        '@components': path.join(__dirname, 'components'),
+        '@interfaces': path.join(__dirname, 'interfaces')
+      },
+      ...config.resolve
+    }
+    return config;
+  }
 }

--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -15,7 +15,8 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@src/*": ["./src/*"]
+      "@components/*": ["components/*"],
+      "@interfaces/*": ["interfaces/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
### What is this PR? 🔍
tsconfig만 설정되어있어서 모듈 alias가 작동하지 않는 버그가 있었습니다.
babel, webpack 설정을 변경하여 모듈 alias를 원활히 사용할 수 있도록 변경했습니다.

----
### Changes📝
~~`@src` : 삭제~~ : 별로 필요없는 것 같습니다.
`@components` : `front-end/components`
`@interfaces`: `front-end/components`
