### PR TITLE
fix: 강의 클릭시에 courses/courseID로 이동하게 수정

### DIFF
--- a/front-end/components/Lectures/LectureCard.tsx
+++ b/front-end/components/Lectures/LectureCard.tsx
@@ -10,8 +10,7 @@ const LectureCard = () => {
 		(state: RootState) => state.lecture,
 	);
 	const handleClick = (id: number) => {
-		//router.push(`/details/${id}`);
-		router.push(`/details`);
+		router.push(`/courses/${id}`);
 	};
 
 	return (


### PR DESCRIPTION
### What is this PR? 🔍
기존에 detail로 이동하던 url 올바르게 이동하게 해결 (확인 완료)

----
### Changes📝

