### PR TITLE
fix(css): 메인페이지 작은 화면에서 너무 컴포넌트들이 무너지는것들 수정

### DIFF
--- a/front-end/components/Main/CardList.tsx
+++ b/front-end/components/Main/CardList.tsx
@@ -24,5 +24,4 @@ const ImageComponent = ({ imageUrl }) => {
 
 const CardWrapper = styled.div`
 	display: flex;
-	max-width: 1650px; // 이 부분도 CONST로 관리 해야함.
 `;

--- a/front-end/components/Main/MainBanner.tsx
+++ b/front-end/components/Main/MainBanner.tsx
@@ -30,12 +30,12 @@ const MainBanner = () => {
 };
 
 const Container = styled.div`
-	width: 100%;
-	background: linear-gradient(#1f5191, #022240);
-	padding: 50px 60px;
+	min-width: 1440px;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	background: linear-gradient(#1f5191, #022240);
+	padding: 50px 60px;
 `;
 
 export default MainBanner;

--- a/front-end/components/Main/Notice.tsx
+++ b/front-end/components/Main/Notice.tsx
@@ -62,7 +62,7 @@ const Container = styled.div`
 `;
 
 const NoticeWrapper = styled.div`
-	max-width: 1650px;
+	width: 100%;
 	display: flex;
 	padding: 40px 40px 40px 50px;
 `;
@@ -71,6 +71,6 @@ const TextCardWrapper = styled.div`
 	display: flex;
 	max-width: 300px;
 	flex-direction: column;
-	white-space: nowrap;
+	/* white-space: nowrap; */
 	padding: 0 20px;
 `;

--- a/front-end/pages/index.tsx
+++ b/front-end/pages/index.tsx
@@ -21,31 +21,35 @@ const Index = () => {
 	}, []);
 
 	return (
-		<Wrapper>
+		<>
 			<MainBanner />
-			<Notice />
-			{/* <Dashboard /> */}
-			<LectureList
-				headerText={'추천 강의(카테고리 무관)'}
-				headerColor={'red'}
-			/>
-			<MidBanner />
-			{/* <LectureList headerText={'최근 강의 이어보기'} headerColor={'orange'} /> */}
-			<MidCategory />
-			<LectureList
-				headerText={'프로그래밍 분야 인기 강의 모음'}
-				headerColor={'purple'}
-			/>
-			<LectureList
-				headerText={'보안 분야 인기 강의 모음'}
-				headerColor={'#df4bff'}
-			/>
-		</Wrapper>
+			<Wrapper>
+				{/* <Notice /> */}
+				{/* <Dashboard /> */}
+				<LectureList
+					headerText={'추천 강의(카테고리 무관)'}
+					headerColor={'red'}
+				/>
+				<MidBanner />
+				{/* <LectureList headerText={'최근 강의 이어보기'} headerColor={'orange'} /> */}
+				<MidCategory />
+				<LectureList
+					headerText={'프로그래밍 분야 인기 강의 모음'}
+					headerColor={'purple'}
+				/>
+				<LectureList
+					headerText={'보안 분야 인기 강의 모음'}
+					headerColor={'#df4bff'}
+				/>
+			</Wrapper>
+		</>
 	);
 };
 
 export default Index;
 
 const Wrapper = styled.div`
+	width: 1440px;
+	margin: auto;
 	font-family: Noto Sans KR;
 `;


### PR DESCRIPTION
### What is this PR? 🔍
- 사이즈에 관계없이 컨텐츠가 일정한 사이즈는 유지되게 수정

----
### Changes📝
- css 수정 (헤더,푸터 제외)
- 사이즈가 작아져도 기본적인 틀은 유지하게 변경했습니다. (아직 모바일 지원 안하기때문)

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/60285506/184669077-886302c7-1a6d-48e4-bae6-e9998af51136.png">

