### PR TITLE
feat: 최근 강의보기 Api 연동

### DIFF
--- a/front-end/components/MyPage/MyPageTitle.tsx
+++ b/front-end/components/MyPage/MyPageTitle.tsx
@@ -1,0 +1,23 @@
+interface IMyPageProps {
+	title?: string;
+}
+
+export const MyPageTitle = ({ title }: IMyPageProps) => {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				width: '100%',
+				background: 'rgba(0, 0, 0, 0.7)',
+				padding: '10px 20px 10px 20px',
+				lineHeight: '28px',
+			}}
+		>
+			<span style={{ color: '#8d8e8e', fontSize: '16px' }}>MY PAGE</span>
+			<span style={{ color: 'white', fontSize: '28px', paddingBottom: '8px' }}>
+				{title}
+			</span>
+		</div>
+	);
+};

--- a/front-end/components/MyPage/MyQna.tsx
+++ b/front-end/components/MyPage/MyQna.tsx
@@ -1,7 +1,8 @@
 import MyPageLayout from '@components/MyPage/MyPageLayout';
 import BreadCrumb from '@components/common/BreadCrumb';
+import { MYPAGE_MENU } from 'constants/MyPage';
 
-const menu = ['질문/답변'];
+const menu = [MYPAGE_MENU.MY_QNA];
 
 const MyQnA = () => {
 	return (

--- a/front-end/components/MyPage/SideMenu.tsx
+++ b/front-end/components/MyPage/SideMenu.tsx
@@ -1,17 +1,24 @@
 import Link from 'next/link';
 import styled from 'styled-components';
-import { MYPAGE_PATH } from 'constants/MyPage';
+import { MYPAGE_PATH, MYPAGE_MENU } from 'constants/MyPage';
 
 const SideMenu = () => {
 	const root = '/my-page';
 	const menus = [
-		{ title: '대시보드', path: root },
-		{ title: '최근 시청 강좌', path: `${root}/${MYPAGE_PATH.HISTORY}` },
-		// { title: '즐겨찾기 강좌', path: `${root}/${MYPAGE_PATH.BOOKMARK}` },
-		{ title: '수강 중인 강좌', path: `${root}/${MYPAGE_PATH.LEARNING}` },
-		{ title: '수강 완료 강좌', path: `${root}/${MYPAGE_PATH.COMPLETED}` },
-		// { title: '찜한 강좌', path: `${root}/${MYPAGE_PATH.WISHLIST}` },
-		{ title: '내 질문/답변', path: `${root}/${MYPAGE_PATH.MY_QNA}` },
+		{ title: MYPAGE_MENU.DASHBOARD, path: root },
+		{
+			title: MYPAGE_MENU.RECENT_WATCHING_LECTURES,
+			path: `${root}/${MYPAGE_PATH.HISTORY}`,
+		},
+		{
+			title: MYPAGE_MENU.CURRENT_WATCHING_LECTURES,
+			path: `${root}/${MYPAGE_PATH.LEARNING}`,
+		},
+		{
+			title: MYPAGE_MENU.COMPLETED_WATCHING_LECTURES,
+			path: `${root}/${MYPAGE_PATH.COMPLETED}`,
+		},
+		{ title: MYPAGE_MENU.MY_QNA, path: `${root}/${MYPAGE_PATH.MY_QNA}` },
 	];
 
 	return (

--- a/front-end/components/MyPage/completed.tsx
+++ b/front-end/components/MyPage/completed.tsx
@@ -1,12 +1,19 @@
 import MyPageLayout from '@components/MyPage/MyPageLayout';
 import BreadCrumb from '@components/common/BreadCrumb';
+import { MyPageTitle } from './MyPageTitle';
+import { MYPAGE_MENU } from 'constants/MyPage';
 
-const menu = ['수강 완료 강좌'];
+const menu = [MYPAGE_MENU.COMPLETED_WATCHING_LECTURES];
 
 const Completed = () => {
 	return (
 		<MyPageLayout>
-			<BreadCrumb category={'MY PAGE'} menu={menu} />
+			<BreadCrumb
+				category={'MY PAGE'}
+				menu={menu}
+				containerPadding={'1rem 0'}
+			/>
+			<MyPageTitle title={MYPAGE_MENU.COMPLETED_WATCHING_LECTURES} />
 		</MyPageLayout>
 	);
 };

--- a/front-end/components/MyPage/history.tsx
+++ b/front-end/components/MyPage/history.tsx
@@ -1,18 +1,69 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import MyPageLayout from '@components/MyPage/MyPageLayout';
 import BreadCrumb from '@components/common/BreadCrumb';
+import { MyPageTitle } from './MyPageTitle';
 
 import axiosInstance from 'apis';
 import { AxiosResponse, AxiosError } from 'axios';
+import { durationToHhMmSs } from 'utils/durationToHhMmSs';
+import { MYPAGE_MENU } from 'constants/MyPage';
+// TODO. css class명 기준 뭘로 할지.. BEM 을 따를지.. 아직 잘 모르겠음
+interface ILatestLectures {
+	duration?: number;
+	filename?: string;
+	id?: number;
+	isFinished?: number; // 0 or 1
+	lastTime?: number;
+	title?: string;
+	updatedAT?: string;
+}
 
-const menu = ['최근 시청 강좌'];
+const menu = [MYPAGE_MENU.RECENT_WATCHING_LECTURES];
 
 const History = () => {
+	const [latestLectures, setLatestLectures] = useState<ILatestLectures[]>();
+
+	const showTimeProgress = (curTime?: number, duration?: number) => {
+		curTime ??= 0;
+		duration ??= 0;
+
+		// 현재 시간이 전체 길이보다 긴 경우 (오류 발생 케이스)
+		if (duration < curTime) {
+			curTime = duration;
+		}
+
+		const _curTime = durationToHhMmSs(curTime);
+		const _duration = durationToHhMmSs(duration);
+		let progressPercentage = 0;
+
+		if (duration) progressPercentage = ~~((curTime / duration) * 100);
+
+		return `${_curTime} / ${_duration} (${progressPercentage}%)`;
+	};
+
 	useEffect(() => {
 		axiosInstance
 			.get('history/latest')
+			.then((res: AxiosResponse) => {
+				setLatestLectures(res.data);
+			})
+			.catch((error: AxiosError) => {
+				console.warn(error);
+			});
+
+		axiosInstance
+			.get('completed')
+			.then((res: AxiosResponse) => {
+				console.log(res.data);
+			})
+			.catch((error: AxiosError) => {
+				console.warn(error);
+			});
+
+		axiosInstance
+			.get('history')
 			.then((res: AxiosResponse) => {
 				console.log(res.data);
 			})
@@ -28,40 +79,20 @@ const History = () => {
 				menu={menu}
 				containerPadding={'1rem 0'}
 			/>
-			<Title />
+			<MyPageTitle title={MYPAGE_MENU.RECENT_WATCHING_LECTURES} />
 
 			<GridWrapper>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
-				<div style={{ width: '100%', background: 'red' }}>1</div>
+				{latestLectures &&
+					latestLectures.map((elem, index) => (
+						<div className="wrapper" key={index}>
+							<div className="title">{elem.title}</div>
+							<div className="time">
+								{showTimeProgress(elem.lastTime, elem.duration)}
+							</div>
+						</div>
+					))}
 			</GridWrapper>
 		</MyPageLayout>
-	);
-};
-
-const Title = () => {
-	return (
-		<div
-			style={{
-				display: 'flex',
-				flexDirection: 'column',
-				width: '100%',
-				background: 'rgba(0, 0, 0, 0.7)',
-				padding: '10px 20px 10px 20px',
-				lineHeight: '28px',
-			}}
-		>
-			<span style={{ color: '#8d8e8e', fontSize: '16px' }}>MY PAGE</span>
-			<span style={{ color: 'white', fontSize: '32px', paddingBottom: '8px' }}>
-				학습중인 강좌
-			</span>
-		</div>
 	);
 };
 
@@ -72,6 +103,27 @@ const GridWrapper = styled.div`
 	grid-row-gap: 16px;
 	grid-template-rows: repeat(3, 1fr);
 	grid-template-columns: repeat(4, 1fr);
+	padding-left: 20px;
+	padding-top: 10px;
+
+	.wrapper {
+		width: 100%;
+		overflow: hidden;
+	}
+
+	.title {
+		font-size: 16px;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.time {
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+		color: rgba(0, 0, 0, 0.5);
+	}
 `;
 
 export default History;

--- a/front-end/components/MyPage/learning.tsx
+++ b/front-end/components/MyPage/learning.tsx
@@ -1,12 +1,20 @@
 import MyPageLayout from '@components/MyPage/MyPageLayout';
 import BreadCrumb from '@components/common/BreadCrumb';
+import { MYPAGE_MENU } from 'constants/MyPage';
+import { MyPageTitle } from './MyPageTitle';
 
-const menu = ['수강 중인 강좌'];
+const menu = [MYPAGE_MENU.CURRENT_WATCHING_LECTURES];
 
 const Learning = () => {
 	return (
 		<MyPageLayout>
-			<BreadCrumb category={'MY PAGE'} menu={menu} />
+			<BreadCrumb
+				category={'MY PAGE'}
+				menu={menu}
+				containerPadding={'1rem 0'}
+			/>
+
+			<MyPageTitle title={MYPAGE_MENU.CURRENT_WATCHING_LECTURES} />
 		</MyPageLayout>
 	);
 };

--- a/front-end/constants/MyPage/index.ts
+++ b/front-end/constants/MyPage/index.ts
@@ -6,3 +6,11 @@ export const MYPAGE_PATH = {
 	WISHLIST: 'wishlist',
 	MY_QNA: 'my-qna',
 };
+
+export const MYPAGE_MENU = {
+	DASHBOARD: '대시보드',
+	RECENT_WATCHING_LECTURES: '최근 시청 강의',
+	CURRENT_WATCHING_LECTURES: '수강 중인 강좌',
+	COMPLETED_WATCHING_LECTURES: '수강 완료 강좌',
+	MY_QNA: '내 질문/답변',
+};

--- a/front-end/pages/index.tsx
+++ b/front-end/pages/index.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import MainBanner from '@components/Main/MainBanner';
-import Notice from '@components/Main/Notice';
 // 1920px 기준임. width별로 다르게 나와야함.
 import LectureList from '@components/Main/LectureList';
 import MidBanner from '@components/Main/MidBanner';

--- a/front-end/pages/my-page/[category].tsx
+++ b/front-end/pages/my-page/[category].tsx
@@ -2,11 +2,11 @@ import { useRouter } from 'next/router';
 import withRouteGuard from '@components/withRouteGuard';
 import { MYPAGE_PATH } from 'constants/MyPage';
 
-import Bookmark from '@components/MyPage/bookmark';
-import Completed from '@components/MyPage/completed';
-import History from '@components/MyPage/history';
-import Learning from '@components/MyPage/learning';
-import MyQnA from '@components/MyPage/my-qna';
+import Bookmark from '@components/MyPage/Bookmark';
+import Completed from '@components/MyPage/Completed';
+import History from '@components/MyPage/History';
+import Learning from '@components/MyPage/Learning';
+import MyQnA from '@components/MyPage/MyQna';
 import Wishlist from '@components/MyPage/wishlist';
 import MyPageIndex from './index';
 


### PR DESCRIPTION
### What is this PR? 🔍
- 최근 강의 api 연동
- 페이지 컴포넌트 이름 소문자로 되어있던것 파스칼 케이스로 변경.
- 중복으로 사용되는 메뉴 이름 constant에서 관리
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/60285506/192150009-1e06ff51-eaab-482e-805d-d42ad8f0c85e.png">

----
### Changes📝
- 텍스트 길이가 길 경우 ... (말줄임 표시)

### TODOS
- api 명세가 수정될 수 있어서, 수정후에 /api 폴더에서  api 호출하게 변경
-  css class명 기준 뭘로 할지 고민. BEM 을 따를지.. 아직 잘 모르겠음