### PR TITLE
feat: 로그인 유저에게 메인에서 최근 수강 강의 노출

### DIFF
--- a/front-end/components/Main/LectureList.tsx
+++ b/front-end/components/Main/LectureList.tsx
@@ -14,16 +14,16 @@ const LectureList = ({ headerText, headerColor }: any) => {
 	return (
 		<div>
 			<CommonHeader text={headerText} color={headerColor} />
-			<div style={{ display: 'flex', padding: '20px 35px', overflowX: 'auto' }}>
+			<GridWrapper>
 				{populars.slice(0, 5).map((lecture, idx) => (
 					<LectureCard key={idx} lecture={lecture} />
 				))}
-			</div>
+			</GridWrapper>
 		</div>
 	);
 };
 
-const CommonHeader = ({ text, color }: any) => {
+export const CommonHeader = ({ text, color }: any) => {
 	return (
 		<Wrapper>
 			<div style={{ position: 'relative' }}>
@@ -56,7 +56,7 @@ const LectureCard = ({ lecture }: any) => {
 
 	return (
 		<LectureCardWrapper onClick={() => handleClick(lecture.id)}>
-			<img src={lecture.thumbnail} onError={handleImgError} />
+			<img width={'100%'} src={lecture.thumbnail} onError={handleImgError} />
 			<div style={{ fontWeight: 'bold' }}>{lecture.title}</div>
 			<div style={{ fontSize: '12px', opacity: '0.6' }}>
 				{lecture.description}
@@ -75,22 +75,19 @@ const Wrapper = styled.div`
 	padding-top: 60px;
 `;
 
-const LectureCardWrapper = styled.div`
-	display: flex;
-	cursor: pointer;
-	flex-direction: column;
-	width: 270px;
-	padding: 10px;
+const GridWrapper = styled.div`
+	display: grid;
+	grid-column-gap: 16px;
+	grid-row-gap: 16px;
+	grid-template-columns: repeat(5, 1fr);
+	padding: 20px 35px;
 `;
 
-const HashTagChip = styled.div`
-	min-width: 60px;
-	background-color: #e6e6e6;
-	border-radius: 10px;
-	white-space: nowrap;
-	font-size: 10px;
-	padding: 3px 6px;
-	margin: 8px 0;
+const LectureCardWrapper = styled.div`
+	cursor: pointer;
+	width: 100%;
+	overflow: hidden;
+	position: relative;
 `;
 
 export default LectureList;

--- a/front-end/components/Main/RecentLecture.tsx
+++ b/front-end/components/Main/RecentLecture.tsx
@@ -1,0 +1,145 @@
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { durationToHhMmSs } from 'utils/durationToHhMmSs';
+import { ILatestLecture } from 'types/MyPage';
+import { AxiosResponse, AxiosError } from 'axios';
+import API from 'apis/MyPage';
+import { CommonHeader } from './LectureList';
+
+type Props = {
+	percentage: number;
+};
+
+export const RecentLecture = () => {
+	const router = useRouter();
+	const [latestLectures, setLatestLectures] = useState<ILatestLecture[]>([]);
+
+	const getProgressPercentage = (curTime?: number, duration?: number) => {
+		curTime ??= 0;
+		duration ??= 0;
+
+		// 현재 시간이 전체 길이보다 긴 경우 (오류 발생 케이스)
+		if (duration < curTime) {
+			curTime = duration;
+		}
+
+		return ~~((curTime / duration) * 100);
+	};
+
+	const showTimeProgress = (curTime?: number, duration?: number) => {
+		curTime ??= 0;
+		duration ??= 0;
+
+		// 현재 시간이 전체 길이보다 긴 경우 (오류 발생 케이스)
+		if (duration < curTime) {
+			curTime = duration;
+		}
+
+		const _curTime = durationToHhMmSs(curTime);
+		const _duration = durationToHhMmSs(duration);
+		let progressPercentage = 0;
+
+		if (duration) progressPercentage = getProgressPercentage(curTime, duration);
+		return `${_curTime} / ${_duration} (${progressPercentage}%)`;
+	};
+
+	const handleClick = (courseId?: number, lectureId?: number) => () => {
+		router.push({ pathname: `/lectures/${lectureId}`, query: { courseId } });
+	};
+
+	useEffect(() => {
+		API.fetchRecentLectures()
+			.then((res: AxiosResponse) => {
+				setLatestLectures(res.data.slice(0, 5));
+			})
+			.catch((error: AxiosError) => {
+				console.warn(error);
+			});
+	}, []);
+
+	return (
+		<>
+			{latestLectures.length > 0 && (
+				<>
+					<CommonHeader text={'최근 수강 강좌'} color={'red'} />
+					<GridWrapper>
+						{latestLectures.map((elem, index) => (
+							<div
+								className="wrapper"
+								onClick={handleClick(elem.lecture.course.id, elem.lecture.id)}
+								key={index}
+							>
+								<img
+									className="image"
+									width={'100%'}
+									src={elem.lecture.course.thumbnail}
+								></img>
+								<ProgressBar
+									percentage={getProgressPercentage(
+										elem.lastTime,
+										elem.lecture.duration,
+									)}
+								>
+									<div className="current_progress_position"></div>
+								</ProgressBar>
+								<div className="title">{elem.lecture.title}</div>
+								<div className="time">
+									{showTimeProgress(elem.lastTime, elem.lecture.duration)}
+								</div>
+							</div>
+						))}
+					</GridWrapper>
+				</>
+			)}
+		</>
+	);
+};
+
+export const GridWrapper = styled.div`
+	display: grid;
+	grid-column-gap: 16px;
+	grid-row-gap: 16px;
+	grid-template-columns: repeat(5, 1fr);
+	padding: 20px 35px;
+	.wrapper {
+		cursor: pointer;
+		width: 100%;
+		overflow: hidden;
+		position: relative;
+	}
+
+	.title {
+		font-size: 16px;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.time {
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+		color: rgba(0, 0, 0, 0.5);
+	}
+
+	.image {
+		aspect-ratio: 16/9;
+	}
+`;
+
+const ProgressBar = styled.div<Props>`
+	position: absolute;
+	bottom: 50px;
+	right: 0;
+	left: 0;
+	height: 4px;
+	background-color: #717171;
+
+	.current_progress_position {
+		position: absolute;
+		height: 100%;
+		width: ${(props) => `${props.percentage}%`};
+		background-color: red;
+	}
+`;

--- a/front-end/pages/index.tsx
+++ b/front-end/pages/index.tsx
@@ -4,11 +4,33 @@ import MainBanner from '@components/Main/MainBanner';
 // 1920px 기준임. width별로 다르게 나와야함.
 import LectureList from '@components/Main/LectureList';
 import MidBanner from '@components/Main/MidBanner';
+import { RecentLecture } from '@components/Main/RecentLecture';
+import { selectIsLoggined } from 'store/feature/common/commonSelector';
+import { useSelector } from 'react-redux';
+import { userLoginAuthState } from 'constants/commonState';
+/*
+TODO. <img> 컴포넌트 next에서 지원하는 Image로 변경 (장점 공부 후에 적용)
+1. 로그인 케이스
+	1.1. 최근 들은 강좌가 1개라도 있는경우 -> 그것 노출.
+	1.2. 최근 들은 강좌가 0개인 경우 -> 인기강의 노출할지.. 아니면 아무것도 안보여줄지
+
+2. 비로그인 케이스
+	2.1. 인기강의 노출
+
+한번만 더 유튜브썸네일 같은 컴포넌트 사용시, 재사용 가능하게 하나 공통으로 만들기
+ 
+1. 로그인 여부 확인. 로그인 되어있으면 보여주면 됨. 강좌 개수 체크
+*/
 const Index = () => {
+	const isLoggined = useSelector(selectIsLoggined);
+
 	return (
 		<>
 			<MainBanner />
 			<Wrapper>
+				{isLoggined && isLoggined === userLoginAuthState.LOGGINED && (
+					<RecentLecture />
+				)}
 				<LectureList headerText={'인기 강의'} headerColor={'red'} />
 				<MidBanner />
 				<LectureList

--- a/front-end/pages/index.tsx
+++ b/front-end/pages/index.tsx
@@ -28,7 +28,7 @@ const Index = () => {
 		<>
 			<MainBanner />
 			<Wrapper>
-				{isLoggined && isLoggined === userLoginAuthState.LOGGINED && (
+				{!!isLoggined && isLoggined === userLoginAuthState.LOGGINED && (
 					<RecentLecture />
 				)}
 				<LectureList headerText={'인기 강의'} headerColor={'red'} />


### PR DESCRIPTION
### What is this PR? 🔍
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/60285506/200176968-091b0745-7cd7-4f81-bbdc-b27e087f2913.png">


----
### Changes📝
- 로그인 유저는 이제 메인에서 최근 수강 강의가 노출됩니다.
- 비로그인, 강의를 신청하지 않은 로그인 유저에게는 노출되지 않습니다.
- grid를 이용해서 5개만 보여주게 수정했습니다.

### TODOS